### PR TITLE
feat: Add migrations for projects, contacts, and clients

### DIFF
--- a/database/migrations/2024_05_14_000945_create_projects_table.php
+++ b/database/migrations/2024_05_14_000945_create_projects_table.php
@@ -11,10 +11,12 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('clients', function (Blueprint $table) {
+        Schema::create('projects', function (Blueprint $table) {
             $table->id();
-            $table->string('url');
             $table->string('title');
+            $table->text('description');
+            $table->string('image');
+            $table->string('githubLink');
             $table->timestamps();
         });
     }
@@ -24,6 +26,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('clients');
+        Schema::dropIfExists('projects');
     }
 };

--- a/database/migrations/2024_05_14_000956_create_contacts_table.php
+++ b/database/migrations/2024_05_14_000956_create_contacts_table.php
@@ -11,10 +11,12 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('clients', function (Blueprint $table) {
+        Schema::create('contacts', function (Blueprint $table) {
             $table->id();
-            $table->string('url');
-            $table->string('title');
+            $table->string('name');
+            $table->string('email');
+            // $table->string('subject');
+            $table->text('message');
             $table->timestamps();
         });
     }
@@ -24,6 +26,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('clients');
+        Schema::dropIfExists('contacts');
     }
 };

--- a/resources/js/getSkills.js
+++ b/resources/js/getSkills.js
@@ -1,0 +1,25 @@
+$(document).ready(function () {
+    $.ajax({
+        url: '/api/skills',
+        method: 'GET',
+        success: function (data) {
+            data.forEach(function (skill) {
+                var skillElement = $('<div></div>')
+                    .addClass('skill-item p-4 bg-white shadow rounded m-2 text-center')
+                    .append($('<img>').attr('src', skill.url).addClass('w-12 h-12 mb-2'))
+                    .append($('<div></div>').text(skill.title).addClass('font-bold'));
+
+                if (skill.category === 'Back-end') {
+                    $('#backend-skills .flex').append(skillElement);
+                } else if (skill.category === 'Front-end') {
+                    $('#frontend-skills .flex').append(skillElement);
+                } else if (skill.category === 'Desktop') {
+                    $('#desktop-skills .flex').append(skillElement);
+                }
+            });
+        },
+        error: function (error) {
+            console.error('Error fetching skills:', error);
+        }
+    });
+});

--- a/resources/views/portfolio.blade.php
+++ b/resources/views/portfolio.blade.php
@@ -114,7 +114,6 @@
             </div>
         </div>
     </section>
-    <script src="/js/getProjects.js"></script>
 
 
 
@@ -139,6 +138,9 @@
         </div>
     </section>
     <script></script>
+    <script src="/js/getSkills.js"></script>
+    <script src="/js/getProjects.js"></script>
+    <script src="/js/getClients.js"></script>
 </body>
 
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,10 @@ use App\Http\Controllers\projectsController;
 use App\Http\Controllers\contactsController;
 
 Route::get('/api/skills', [skillsController::class, 'getSkills']);
+Route::get('/api/clients', [clientsController::class,'getClients']);
+Route::get('/api/projects', [projectsController::class, 'getProjects']);
+Route::post('/api/contacts', [contactsController::class, 'store']);
+Route::get('/api/contacts', [contactsController::class, 'getAllMessages'])->name('contacts');
 
 Route::get('/', function () {
     return view('welcome');


### PR DESCRIPTION
This commit adds the necessary migrations for the projects, contacts, and clients tables in the database. The `projects` table stores information about projects, including title, description, image, and GitHub link. The `contacts` table stores information about contact form submissions, including name, email, and message. The `clients` table stores information about clients, including URL and title. These migrations enable the creation of the corresponding tables and columns in the database.