### PR TITLE
feat: Add functionality to add projects

### DIFF
--- a/app/Http/Controllers/projectsController.php
+++ b/app/Http/Controllers/projectsController.php
@@ -16,6 +16,17 @@ class projectsController extends Controller
         return $projects;
     }
 
+    public function addproject(Request $request)
+    {
+        $project = new projects();
+        $project->title = $request->title;
+        $project->description = $request->description;
+        $project->image = $request->image;
+        $project->githubLink = $request->githubLink;
+        $project->save();
+        return redirect()->back()->with('success', 'Project added successfully!');
+    }
+
     /**
      * Show the form for creating a new resource.
      */

--- a/app/Models/projects.php
+++ b/app/Models/projects.php
@@ -8,4 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 class projects extends Model
 {
     use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'image',
+        'githubLink',
+    ];
 }

--- a/public/js/contact_form.js
+++ b/public/js/contact_form.js
@@ -1,0 +1,31 @@
+// contact_form.js
+
+document.getElementById('contact-form').addEventListener('submit', function(event) {
+    // Empêcher le comportement de soumission par défaut du formulaire
+    // event.preventDefault();
+
+    // Récupérer les données du formulaire
+    var name = event.target.elements.name.value;
+    var email = event.target.elements.email.value;
+    var message = event.target.elements.message.value;
+
+    // Envoyer une requête POST à l'API
+    fetch('http://127.0.0.1:8000/api/contacts', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            // Si vous utilisez Laravel CSRF protection, ajoutez le token ici
+            // 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+        },
+        body: JSON.stringify({
+            name: name,
+            email: email,
+            message: message,
+        }),
+    })
+    .then(response => response.json())
+    .then(data => console.log(data))
+    .catch((error) => {
+        console.error('Error:', error);
+    });
+});

--- a/resources/views/Admin/dashboard.blade.php
+++ b/resources/views/Admin/dashboard.blade.php
@@ -67,7 +67,7 @@
                 <!-- Add Project Form -->
                 <section id="add-project" class="mb-8">
                     <h2 class="text-lg font-semibold mb-4">Add Project</h2>
-                    <form action="" method="POST" class="space-y-4">
+                    <form action="{{route('add-project')}}" method="POST" class="space-y-4">
                         @csrf
                         <div>
                             <label for="title" class="block font-semibold">Project Title</label>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ Route::get('/api/clients', [clientsController::class,'getClients']);
 Route::get('/api/projects', [projectsController::class, 'getProjects']);
 Route::post('/api/contacts', [contactsController::class, 'store']);
 Route::get('/api/contacts', [contactsController::class, 'getAllMessages'])->name('contacts');
+Route::post('/api/projects', [projectsController::class, 'addproject'])->name('add-project');
 
 Route::get('/', function () {
     return view('welcome');


### PR DESCRIPTION
The code changes include adding a new method `addproject` to the `projectsController` that handles the logic for adding a new project. The method creates a new instance of the `projects` model, sets the title, description, image, and GitHub link based on the request data, and saves the project to the database. The method then redirects back to the previous page with a success message. Additionally, the `projects` model is updated to include the fillable fields for title, description, image, and GitHub link.